### PR TITLE
Historization: old and new paths are identical

### DIFF
--- a/src/Routing/Canonical.php
+++ b/src/Routing/Canonical.php
@@ -90,11 +90,37 @@ class Canonical
         $params = [];
         foreach ($seo->getRouteParameters() as $routeParam) {
             /** @var RouteParameter $routeParam */
-            $propName                            = $routeParam->getProperty();
-            $params[$routeParam->getParameter()] =
-                $overrides[$propName] ?? $this->propAccess->getValue($entity, $propName);
+            $params[$routeParam->getParameter()] = $this->getParamValue($entity, $routeParam, $overrides);
         }
 
         return $params;
+    }
+
+    /**
+     * In case an $overrides array is given, extracts the name
+     * of the property in the current entity and returns the
+     * value associated to it in the $overrides array
+     *
+     * By default, return the value as found by the property
+     * accessor
+     *
+     * @param                $entity
+     * @param RouteParameter $routeParam
+     * @param array          $overrides
+     *
+     * @return mixed
+     */
+    private function getParamValue($entity, RouteParameter $routeParam, array $overrides = [])
+    {
+        if (!empty($overrides)) {
+            $prop = explode('.', $routeParam->getProperty());
+            $prop = reset($prop);
+
+            if (array_key_exists($prop, $overrides)) {
+                return $overrides[$prop];
+            }
+        }
+
+        return $this->propAccess->getValue($entity, $routeParam->getProperty());
     }
 }


### PR DESCRIPTION
### Premise
When modifying an entity annotated with `@Route`, if the parameter being modified is a linked entity, the `old_path` and `new_path` properties for the new `UrlHistory` are the same.
The `new_path` value is the correct one.


### Patches
- The `array_walk` that was used to get the old parameter value doesn't quite do the job in our context. It has been replaced with a foreach, intended to be able to handle objects (when the changed field is an objet) as well.
- Adds a method to get the value recursively from a reflection class if the changed field is an object, trying every parent class until the value is found. If the value can't be found, throws an exception so that it is ignored
- Adds a method to the `Canonical` class to get the value from the overrides array if it's been provided (the previous ternary in `buildParams()` was too simple for more complex cases)
- Replaces said ternary with a call to the aforementioned method (useful when guessing the old path from compound properties)