### PR TITLE
fix: corrige condition quand $mappingData est un objet

### DIFF
--- a/src/Doctrine/EventSubscriber/UrlHistoryWriter.php
+++ b/src/Doctrine/EventSubscriber/UrlHistoryWriter.php
@@ -53,7 +53,7 @@ class UrlHistoryWriter
 
         // Loops through each entity associations
         foreach ($args->getClassMetadata()->getAssociationMappings() as $mappingData) {
-            if (!\array_key_exists('targetEntity', $mappingData)) {
+            if (\is_array($mappingData) && !\array_key_exists('targetEntity', $mappingData)) {
                 continue;
             }
 


### PR DESCRIPTION
Bug rencontré dans `doctrine/orm` v3.5 : `$mappingData` est un object, donc `\array_key_exists('targetEntity', $mappingData)` renvoie une erreur.
J'ai ajouté une condition pour assurer la compatibilité avec toutes les versions de `doctrine/orm` supportées par le bundle.
J'ai vérifié que la ligne `$targetEntityClass = $mappingData['targetEntity'];` fonctionne correctement quand `mappingData` est un objet.